### PR TITLE
feat: Upgrade eslint-plugin-vue

### DIFF
--- a/eslint/package.json
+++ b/eslint/package.json
@@ -27,7 +27,7 @@
     "eslint": "^7.30.0",
     "eslint-plugin-file-progress": "^1.1.1",
     "eslint-plugin-import": "^2.24.0",
-    "eslint-plugin-vue": "^7.8.0",
+    "eslint-plugin-vue": "^7.16.0",
     "typescript": "^4.2.3"
   },
   "bugs": {


### PR DESCRIPTION
When use vue3 SFC<script setup>,
function defineProps and defineEmits need be ignored,
these rule be used in eslint-plugin-vue v7.13.0 .